### PR TITLE
Assigned unsupported uBO syntaxes

### DIFF
--- a/platforms.json
+++ b/platforms.json
@@ -277,7 +277,14 @@
                 "\\$protobuf",
                 "important,protobuf",
                 "\\$extension",
-                ",extension"
+                ",extension",
+                "\\$jsinject",
+                ",jsinject",
+                "\\$urlblock",
+                ",urlblock",
+                "\\$content",
+                ",content",
+                "$webrtc"
             ],
             "ignoreRuleHints": false,
             "adbHeader": "![Adblock Plus 2.0]"

--- a/platforms.json
+++ b/platforms.json
@@ -286,7 +286,7 @@
                 ",content",
                 "$webrtc",
                 "#@%#",
-                "#$#@media "
+                "#\\$#@media "
             ],
             "ignoreRuleHints": false,
             "adbHeader": "![Adblock Plus 2.0]"

--- a/platforms.json
+++ b/platforms.json
@@ -284,7 +284,9 @@
                 ",urlblock",
                 "\\$content",
                 ",content",
-                "$webrtc"
+                "$webrtc",
+                "#@%#",
+                "#$#@media "
             ],
             "ignoreRuleHints": false,
             "adbHeader": "![Adblock Plus 2.0]"


### PR DESCRIPTION
I assigned 6 syntaxes as not being accepted by uBO, so I figured one could just as well ensure that such entries were excluded from the generated list versions for uBO to save a small bit of filesize.

If I've done this correctly, this would shave around 70 entries from the uBO version of AdGuard Base filter. I've turned on the "Allow edits by maintainers" button.