### PR TITLE
Throw when converting a scriptlet with path option to uBO syntax

### DIFF
--- a/src/main/rule/cosmetic-rule-modifiers.js
+++ b/src/main/rule/cosmetic-rule-modifiers.js
@@ -54,8 +54,7 @@ const convertAdgPathModifierToUbo = (rule) => {
     const isScriptlet = content.startsWith('//scriptlet');
 
     if (isScriptlet) {
-        const uboScriptletRule = scriptlets.convertAdgToUbo(`${domainsPattern}${marker}${content}`);
-        return `${uboScriptletRule}:matches-path(${path})`;
+        throw new Error(`Path option "${path}" not supported by uBO scriptlet syntax`);
     }
 
     return `${domainsPattern}${marker}:matches-path(${path})${content}`;

--- a/src/test/converter.test.js
+++ b/src/test/converter.test.js
@@ -572,11 +572,10 @@ describe('converter', () => {
 
     it('converts scriplet rule  with modifiers to UBlock syntax', () => {
         const source = String.raw`[$path=/page,domain=example.com|~example.org]#%#//scriptlet('ubo-setTimeout-defuser.js', '[native code]', '8000')`;
-        const expected = String.raw`example.com,~example.org##+js(no-setTimeout-if, [native code], 8000):matches-path(/page)`;
 
         let rulesList = converter.convertAdgPathModifierToUbo([source]);
         rulesList = converter.convertAdgScriptletsToUbo(rulesList);
 
-        expect(rulesList[0]).toEqual(expected);
+        expect(rulesList).toHaveLength(0);
     });
 });


### PR DESCRIPTION
uBO's scriptlet syntax does not support AdGuard's `[path=...]` option.

To prevent conversion to invalid filter, the conversion will error when attempting to convert an AdGuard scriptlet with a path option present.

Related issue:
- https://github.com/AdguardTeam/tsurlfilter/issues/65