### PR TITLE
Handling syntaxes that uBO's logger consider to be unsupported

### DIFF
--- a/src/main/platforms-config.js
+++ b/src/main/platforms-config.js
@@ -436,8 +436,8 @@ const JAVASCRIPT_RULES_PATTERNS = [
  * ```windowslite.net#$#body { overflow: auto !important; }```
  */
 const CSS_RULES_PATTERNS = [
-    '#%#',
-    '#@%#',
+    '#\\$#',
+    '#@\\$#',
 ];
 
 /**
@@ -536,17 +536,27 @@ const SAFARI_BASED_EXTENSION_PATTERNS = [
 ];
 
 /**
- * Pattern to detect entries which are not supported in uBlock Origin
- * among them known to be `:matches-property` and generic style rules
+ * Pattern to detect Extended CSS `:matches-property()` rules
  *
  * @example
  * ```unsplash.com#?#.ripi6 > div:matches-property(/__reactFiber/.return.return.memoizedProps.ad)```
  * @example
- * ```##div[class="adsbygoogle"][id="ad-detector"] { display: block !important; }```
+ * ```androidauthority.com#?#main div[class]:has(> div[class]:matches-property(/__reactFiber/.return.memoizedProps.type=med_rect_atf))```
  */
-const UBLOCK_BASED_EXTENSION_PATTERNS = [
+const CSS_MATCHES_PROPERTY_RULES_PATTERNS = [
     ':matches-property\\(',
-    '^#.* ?\{ ?[a-z]'
+];
+
+/**
+ * Pattern to detect generic CSS rules
+ *
+ * @example
+ * ```#$#div[class="adsbygoogle"][id="ad-detector"] { display: block !important; }```
+ * @example
+ * ```#$#.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links { display: block !important; }```
+ */
+const CSS_GENERIC_RULES_PATTERNS = [
+    '^#\\$#',
 ];
 
 module.exports = {
@@ -800,7 +810,8 @@ module.exports = {
                 ...JSONPRUNE_MODIFIER_PATTERNS,
                 ...UNBLOCKING_IMPORTANT_RULES_PATTERNS,
                 ...REMOVEHEADER_MODIFIER_PATTERNS,
-                ...UBLOCK_BASED_EXTENSION_PATTERNS,
+                ...CSS_MATCHES_PROPERTY_RULES_PATTERNS, // TODO: remove when this issue is fixed - https://github.com/AdguardTeam/FiltersCompiler/issues/252
+                ...CSS_GENERIC_RULES_PATTERNS,
             ],
             'ignoreRuleHints': false,
             'adbHeader': '![Adblock Plus 2.0]',

--- a/src/main/platforms-config.js
+++ b/src/main/platforms-config.js
@@ -2,7 +2,7 @@
  * @file Platforms configuration.
  *
  * It shall be overridden by custom configuration:
- * @see {@link https://github.com/AdguardTeam/FiltersRegistry/blob/master/custom_platforms.js}
+ * @see {@link https://github.com/AdguardTeam/FiltersRegistry/blob/master/scripts/build/custom_platforms.js}
  *
  * IMPORTANT: During making any changes in this file,
  * the custom_platforms.js should also be updated through PR on GitHub.

--- a/src/main/platforms-config.js
+++ b/src/main/platforms-config.js
@@ -535,6 +535,20 @@ const SAFARI_BASED_EXTENSION_PATTERNS = [
     ...JSONPRUNE_MODIFIER_PATTERNS,
 ];
 
+/**
+ * Pattern to detect entries which are not supported in uBlock Origin
+ * among them known to be `:matches-property` and generic style rules
+ *
+ * @example
+ * ```unsplash.com#?#.ripi6 > div:matches-property(/__reactFiber/.return.return.memoizedProps.ad)```
+ * @example
+ * ```##div[class="adsbygoogle"][id="ad-detector"] { display: block !important; }```
+ */
+const UBLOCK_BASED_EXTENSION_PATTERNS = [
+    ':matches-property\\(',
+    '^#.* ?\{ ?[a-z]'
+];
+
 module.exports = {
     'WINDOWS': {
         'platform': 'windows',
@@ -785,6 +799,8 @@ module.exports = {
                 ...REFERRERPOLICY_MODIFIER_PATTERNS,
                 ...JSONPRUNE_MODIFIER_PATTERNS,
                 ...UNBLOCKING_IMPORTANT_RULES_PATTERNS,
+                ...REMOVEHEADER_MODIFIER_PATTERNS,
+                ...UBLOCK_BASED_EXTENSION_PATTERNS,
             ],
             'ignoreRuleHints': false,
             'adbHeader': '![Adblock Plus 2.0]',


### PR DESCRIPTION
Syncing AdGuard Base's uBO version in uBO gives these notes in uBO's logger as of uO 1.63.3b9:

![image](https://github.com/user-attachments/assets/fc2f26bf-2cd5-49ac-9da4-25258dfb4fb0)

So I figured, "Okay, I can at least give it a try to handle the `$removeheader`, `:matches-property` and generic style ones".

The "Allow edits by maintainers" button has been turned on for this PR.